### PR TITLE
Rust building on travis.ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,5 +39,5 @@ script:
   - make clean && make all config=debug_x64 && ./bin/test
   - make clean && make all config=release_x64 && ./bin/test
   - cd ../rust
-#  - cargo build --verbose
-#  - cargo test --verbose
+  - cargo build --verbose
+  - cargo test --verbose

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -8,13 +8,13 @@ use std::time::{SystemTime, Duration};
 use std::cmp;
 
 pub fn main() {
-/*
-    #[cfg(not(target_os = "windows"))]
+
+    #[cfg(target_os = "windows")]
     {
         println!("cargo:rustc-link-search=native=../c/windows");
         println!("cargo:rustc-link-lib=static=sodium-release");
     }
-*/
+
     gcc::Config::new()
         .file("../c/netcode.c")
         .include("../c")

--- a/rust/build.rs
+++ b/rust/build.rs
@@ -4,8 +4,7 @@ extern crate bindgen;
 use std::env;
 use std::path::PathBuf;
 use std::fs::File;
-use std::time::{SystemTime, Duration};
-use std::cmp;
+use std::time::{Duration};
 
 pub fn main() {
 

--- a/rust/todo.md
+++ b/rust/todo.md
@@ -5,7 +5,7 @@
 - [DONE] Add connect() support to mio.
 - [DONE] Socking mocking scaffold to swap zero-cost implemenations.
 - [DONE] Build on *nix platforms(should be drop-in but need to verify).
-- [TODO] Use better mechansim to find libsodium on linux.
+- [TODO] Use better mechanism to find libsodium on linux.
 - [TODO] Working server implemenation.
 - [TODO] In-place libsodium decode.
 - [TODO] Appveyor/travis.ci auto-build.

--- a/rust/todo.md
+++ b/rust/todo.md
@@ -4,8 +4,9 @@
 - [DONE] Serialize all packet + token(challenge & connection) in a form that's compatible with C API.
 - [DONE] Add connect() support to mio.
 - [DONE] Socking mocking scaffold to swap zero-cost implemenations.
+- [DONE] Build on *nix platforms(should be drop-in but need to verify).
+- [TODO] Use better mechansim to find libsodium on linux.
 - [TODO] Working server implemenation.
 - [TODO] In-place libsodium decode.
-- [TODO] Build on *nix platforms(should be drop-in but need to verify).
 - [TODO] Appveyor/travis.ci auto-build.
 - [TODO] Socket mocking layer to introduce latency/dropped packets for testing.


### PR DESCRIPTION
I've got the Rust code + unit tests running on travis.ci.

I also forgot about how GitHub does pull requests so a couple commits from my last PR made it in there. I'm going to use feature branches in the future so that doesn't happen again.

Here's the passing build that shows them building: https://travis-ci.org/vvanders/netcode.io/builds/217614900

The rust side is a bit verbose due to dead_code warnings but should clean up as I get more things implemented. If the warnings are annoying then I can clean them up but might take me a bit.