### PR TITLE
Adding example and fixing intermittent crash

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "netcode"
-version = "0.2.2"
+version = "0.3.0"
 authors = ["Val Vanderschaegen <valere.vanderschaegen@gmail.com>"]
 build = "build.rs"
 links = "libnetcode"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -14,11 +14,18 @@ description = "Wrapper for netcode.io library"
 libsodium-sys = "0.0.14"
 log = "0.3.6"
 byteorder = "1.0.0"
+env_logger = "0.4.2"
+time = "0.1.36"
 
 [dev-dependencies]
-env_logger = "0.4.2"
 lazy_static = "0.2.6"
 
 [build-dependencies]
 gcc = "0.3.43"
 bindgen = "0.22.1"
+
+[[bin]]
+path = "src/example.rs"
+name = "example"
+
+[lib]

--- a/rust/src/channel.rs
+++ b/rust/src/channel.rs
@@ -7,7 +7,7 @@ use socket::SocketProvider;
 use std::net::SocketAddr;
 
 pub const TIMEOUT_SECONDS: u32 = 5;
-pub const KEEPALIVE_RETRY: f64 = 1.0 / 10.0;
+pub const KEEPALIVE_RETRY: f64 = 1.0 / 1.0;
 
 #[derive(Clone, Debug)]
 pub struct KeepAliveState {
@@ -23,18 +23,12 @@ impl KeepAliveState {
         }
     }
 
-    pub fn update_sent(&self, time: f64) -> KeepAliveState {
-        KeepAliveState {
-            last_sent: time,
-            last_response: self.last_response
-        }
+    pub fn update_sent(&mut self, time: f64) {
+        self.last_sent = time;
     }
 
-    pub fn update_response(&self, response: f64) -> KeepAliveState {
-        KeepAliveState {
-            last_sent: self.last_sent,
-            last_response: response
-        }
+    pub fn update_response(&mut self, response: f64) {
+        self.last_response = response;
     }
 
     pub fn has_expired(&self, time: f64) -> bool {
@@ -121,6 +115,7 @@ impl Channel {
     pub fn update<I,S>(&mut self, elapsed: f64, socket: &mut I, send_keep_alive: bool) -> Result<UpdateResult, SendError> where I: SocketProvider<I,S> {
         if self.keep_alive.should_send_keepalive(elapsed) {
             if send_keep_alive {
+                trace!("Sending keep alive");
                 self.send_keep_alive(elapsed, socket)?;
             }
 

--- a/rust/src/example.rs
+++ b/rust/src/example.rs
@@ -1,0 +1,133 @@
+extern crate netcode;
+extern crate time;
+extern crate log;
+extern crate env_logger;
+
+use netcode::{UdpServer, ServerEvent, UdpClient, ClientEvent, ClientState, NETCODE_MAX_PAYLOAD_SIZE};
+
+use std::thread;
+use std::sync::mpsc;
+use std::time::Duration;
+use std::io::{self, BufRead};
+
+const MAX_CLIENTS: usize = 256;     //Total number of clients we support
+const PROTOCOL_ID: u64 = 0xFFDDEE;  //Unique protocol id for our application.
+const TOKEN_LIFETIME: usize = 15;   //Our token lives 15 seconds.
+
+const CLIENT_ID: u64 = 0xDDEEFF;    //Single unique client id, you'll want to tie this into
+                                    // your user store in production.
+
+const TICK_TIME_MS: f64 = 0.016; //Tick every 16ms
+
+//Helper function for sleeping at a regular interval
+fn sleep_for_tick(last_tick: &mut f64) -> f64 {
+    let now = time::precise_time_s();
+
+    let elapsed = (now - *last_tick).min(TICK_TIME_MS);
+
+    if elapsed < TICK_TIME_MS {
+        let sleep_ms = ((TICK_TIME_MS - elapsed) * 1000.0).floor() as u64;
+        thread::sleep(Duration::from_millis(sleep_ms));
+    }
+
+    *last_tick = now;
+    TICK_TIME_MS
+}
+
+fn main() {
+    {
+        use env_logger::LogBuilder;
+        use log::LogLevelFilter;
+
+        //Uncomment the below line to turn on verbose debugging for netcode
+        //LogBuilder::new().filter(None, LogLevelFilter::Trace).init().unwrap();
+    }
+
+    let mut server = UdpServer::new("127.0.0.1:0", MAX_CLIENTS, PROTOCOL_ID, &netcode::generate_key()).unwrap();
+    let token = server.generate_token(TOKEN_LIFETIME, CLIENT_ID, None).unwrap();
+
+    let server_thread = thread::spawn(move || {
+        let mut last = 0.0;
+        loop {
+            let elapsed = sleep_for_tick(&mut last);
+            server.update(elapsed).unwrap();
+
+            let mut packet = [0; NETCODE_MAX_PAYLOAD_SIZE];
+            while let Some(event) = server.next_event(&mut packet).unwrap() {
+                match event {
+                    ServerEvent::ClientConnect(_id) => println!("Server: client connected"),
+                    ServerEvent::ClientDisconnect(_id) => {
+                        //Once our single client is done we should exit.
+                        return
+                    },
+                    ServerEvent::Packet(id, size) => {
+                        println!("Heard packet, echoing back");
+                        server.send(id, &packet[..size]).unwrap();
+                    },
+                    ServerEvent::SentKeepAlive(_id) => {},
+                    ServerEvent::RejectedClient => {},
+                    ServerEvent::ReplayRejected(_id) => {},
+                    ServerEvent::ClientSlotFull => {}
+                }
+            }
+        }
+    });
+
+    let mut client = UdpClient::new(&token).unwrap();
+
+    let (tx, rx) = mpsc::channel();
+    let client_thread = thread::spawn(move || {
+        let mut last = 0.0;
+        loop {
+            let elapsed = sleep_for_tick(&mut last);
+            client.update(elapsed).unwrap();
+
+            let mut packet = [0; NETCODE_MAX_PAYLOAD_SIZE];
+            while let Some(event) = client.next_event(&mut packet).unwrap() {
+                match event {
+                    ClientEvent::NewState(state) => match state {
+                        ClientState::Disconnected => return,
+                        s => println!("Client: new state {:?}", s)
+                    },
+                    ClientEvent::Packet(len) => {
+                        println!("{}", String::from_utf8_lossy(&packet[..len]));
+                    },
+                    ClientEvent::SentKeepAlive => {}
+                }
+            }
+
+            let result: Option<String> = match rx.try_recv() {
+                Ok(v) => Some(v),
+                Err(mpsc::TryRecvError::Empty) => None,
+                Err(_) => {
+                    client.disconnect().unwrap_or(());
+                    None
+                }
+            };
+
+            match result {
+                Some(ref s) if s == "exit" => {
+                    client.disconnect().unwrap_or(());
+                    return
+                },
+                Some(s) => client.send(&s.into_bytes()).map(|_| ()).unwrap_or(()),
+                None => ()
+            }
+        }
+    });
+
+    //Read a line from stdin and send it to our client to process.
+    let stdin = io::stdin();
+    for line in stdin.lock().lines() {
+        let value = line.unwrap();
+        if value == "exit" {
+            tx.send(value).unwrap();
+            break;
+        } else {
+            tx.send(value).unwrap()
+        }
+    }
+
+    client_thread.join().unwrap();
+    server_thread.join().unwrap();
+}

--- a/rust/src/example.rs
+++ b/rust/src/example.rs
@@ -1,3 +1,11 @@
+//! Sample netcode echo client + server. This is the bare minimum needed to show a full
+//! working example. Creates two threads one for the server and one for the client.
+//! The main thread listens for new lines and sends them to the client with a mpsc channel.
+//! The client will then send the string to the server and the server will echo it back to the
+//! client. Note that since this is a UDP based protocol it's expected some messages will be dropped.
+//! Once done the string "exit" will cause the client to disconnect which the server will then 
+//! terminate when it hears the disconnect from the client.
+
 extern crate netcode;
 extern crate time;
 extern crate log;
@@ -35,13 +43,15 @@ fn sleep_for_tick(last_tick: &mut f64) -> f64 {
 }
 
 fn main() {
+    //Uncomment the below block to turn on verbose debugging for netcode
+    /*
     {
         use env_logger::LogBuilder;
         use log::LogLevelFilter;
 
-        //Uncomment the below line to turn on verbose debugging for netcode
-        //LogBuilder::new().filter(None, LogLevelFilter::Trace).init().unwrap();
+        LogBuilder::new().filter(None, LogLevelFilter::Trace).init().unwrap();
     }
+    */
 
     let mut server = UdpServer::new("127.0.0.1:0", MAX_CLIENTS, PROTOCOL_ID, &netcode::generate_key()).unwrap();
     let token = server.generate_token(TOKEN_LIFETIME, CLIENT_ID, None).unwrap();

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -18,8 +18,7 @@
 //!
 //! const PROTOCOL_ID: u64 = 0xFFEE;
 //! const MAX_CLIENTS: usize = 32;
-//! let private_key = netcode::generate_key();
-//! let mut server = UdpServer::new("127.0.0.1:0", MAX_CLIENTS, PROTOCOL_ID, &private_key).unwrap();
+//! let mut server = UdpServer::new("127.0.0.1:0", MAX_CLIENTS, PROTOCOL_ID, &netcode::generate_key()).unwrap();
 //!
 //! //loop {
 //!     server.update(1.0 / 10.0);
@@ -67,6 +66,6 @@ mod socket;
 pub use token::{ConnectToken};
 pub use common::{NETCODE_MAX_PACKET_SIZE, NETCODE_MAX_PAYLOAD_SIZE, NETCODE_USER_DATA_BYTES};
 pub use server::{UdpServer, Server, ServerEvent};
-pub use client::{UdpClient, Client, ClientEvent};
+pub use client::{UdpClient, Client, ClientEvent, State as ClientState};
 pub use crypto::{generate_key};
 pub use error::*;

--- a/rust/src/server/mod.rs
+++ b/rust/src/server/mod.rs
@@ -520,7 +520,7 @@ impl<I,S> ServerInternal<I,S> where I: SocketProvider<I,S> {
         }
 
         trace!("Handling packet from client");
-            let decoded = match client.channel.recv(self.time, packet, out_packet) {
+        let decoded = match client.channel.recv(self.time, packet, out_packet) {
             Ok(packet) => packet,
             Err(RecvError::DuplicateSequence) => return Ok(Some(ServerEvent::ReplayRejected(client.client_id))),
             Err(e) => {

--- a/rust/src/token.rs
+++ b/rust/src/token.rs
@@ -164,7 +164,7 @@ impl ConnectToken {
                        sequence: u64,
                        protocol: u64,
                        client_id: u64,
-                       user_data: Option<&[u8; 256]>)
+                       user_data: Option<&[u8; NETCODE_USER_DATA_BYTES]>)
                        -> Result<ConnectToken, GenerateError>
                           where H: ExactSizeIterator<Item=SocketAddr> {
         if hosts.len() > NETCODE_MAX_SERVERS_PER_CONNECT {


### PR DESCRIPTION
I finally tracked down the intermittent crash we were seeing with the Rust unit tests. Turns out I wasn't calling sodium_init(). Since doing that I've been able to run the tests in a loop for 30mins straight without a crash.

I spent a fair bit of time trying to get -fsanitizer working with Rust. No luck but I ran it on the C unit tests and saw a few leaks + uninitialized reads(-fsanitizer=memory). Didn't get any callstacks but let me know if you're interested in tracking them down I can share the command I built it with.

I've also started adding a simple example which helped me flush out a few more bugs. I think the client is almost at the point where I want to let people start consuming it so I've bumped the crate version so I can publish to crates.io.