### PR TITLE
[Rust] Fixed a bug where new clients are only accepted in first 5 seconds

### DIFF
--- a/rust/src/channel.rs
+++ b/rust/src/channel.rs
@@ -16,10 +16,10 @@ pub struct KeepAliveState {
 }
 
 impl KeepAliveState {
-    pub fn new() -> KeepAliveState {
+    pub fn new(current_time: f64) -> KeepAliveState {
         KeepAliveState {
-            last_sent: 0.0,
-            last_response: 0.0
+            last_sent: current_time,
+            last_response: current_time
         }
     }
 
@@ -65,9 +65,10 @@ impl Channel {
                addr: &SocketAddr,
                protocol_id: u64,
                client_idx: usize,
-               max_clients: usize) -> Channel {
+               max_clients: usize,
+               time: f64) -> Channel {
         Channel {
-            keep_alive: KeepAliveState::new(),
+            keep_alive: KeepAliveState::new(time),
             send_key: send_key.clone(),
             recv_key: recv_key.clone(),
             replay_protection: ReplayProtection::new(),

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -160,7 +160,7 @@ mod token;
 mod packet;
 mod socket;
 
-pub use token::{ConnectToken};
+pub use token::{ConnectToken, DecodeError};
 pub use common::{NETCODE_MAX_PACKET_SIZE, NETCODE_MAX_PAYLOAD_SIZE, NETCODE_USER_DATA_BYTES};
 pub use server::{UdpServer, Server, ServerEvent};
 pub use client::{UdpClient, Client, ClientEvent, State as ClientState};

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -1,7 +1,7 @@
 //! Rust implementation of netcode.io protocol.
 //!
 //! This crate contains [Server](struct.Server.html), [Client](struct.Client.html) and [ConnectToken](struct.ConnectToken.html) used to establish a netcode.io session.
-//! 
+//!
 //! # Connect Token
 //! Each netcode.io session starts with a [ConnectToken](struct.ConnectToken.html). This token is handed out by a HTTPS webserver, authentication server or other *private* avenue
 //! to allow a client to establish a connection with a netcode.io based server. Rather than specifying an address the list of hosts are contained within
@@ -104,7 +104,7 @@
 //! let client_id = get_client_id(); //Unique u64 client id.
 //! let sequence = get_next_sequence(); //sequence passed to generate() must
 //!                                     //be a monotically increasing u64
-//!                                     //to prevent replay attacks.                                        
+//!                                     //to prevent replay attacks.
 //! let user_data = None;   //Any custom user data, can be up to 256 bytes.
 //!                         //Will be encrypted and returned to sever on connect.
 //!

--- a/rust/src/packet.rs
+++ b/rust/src/packet.rs
@@ -172,7 +172,7 @@ pub fn encode(out: &mut [u8], protocol_id: u64, packet: &Packet, crypt_info: Opt
 
         Ok(writer.position() as usize)
     } else {
-        if let Some((sequence,private_key)) = crypt_info {
+        if let Some((sequence, private_key)) = crypt_info {
             let (prefix_byte, offset) = {
                 let mut write = &mut io::Cursor::new(&mut out[..]);
 
@@ -727,7 +727,7 @@ fn test_decode_challenge_token() {
             capi_scratch.as_mut_ptr(),
             capi_scratch.len() as i32,
             &mut native_token);
-            
+
         assert_eq!(serialize, 1);
         assert_eq!(native_token.client_id, client_id);
         for i in 0..user_data.len() {

--- a/rust/src/server/mod.rs
+++ b/rust/src/server/mod.rs
@@ -128,7 +128,7 @@ enum TickResult {
 
 impl<I,S> Server<I,S> where I: SocketProvider<I,S> {
     /// Constructs a new Server bound to `local_addr` with `max_clients` and supplied `private_key` for authentication.
-    pub fn new<A>(local_addr: A, max_clients: usize, protocol_id: u64, private_key: &[u8; NETCODE_KEY_BYTES]) 
+    pub fn new<A>(local_addr: A, max_clients: usize, protocol_id: u64, private_key: &[u8; NETCODE_KEY_BYTES])
             -> Result<Server<I,S>, CreateError>
             where A: ToSocketAddrs {
         let bind_addr = local_addr.to_socket_addrs().unwrap().next().unwrap();
@@ -215,7 +215,7 @@ impl<I,S> Server<I,S> where I: SocketProvider<I,S> {
     pub fn update(&mut self, elapsed: f64) {
         self.internal.update(elapsed);
     }
-    
+
     /// Checks for incoming packets, client connection and disconnections. Returns `None` when no more events
     /// are pending.
     pub fn next_event(&mut self, out_packet: &mut [u8; NETCODE_MAX_PAYLOAD_SIZE]) -> Result<Option<ServerEvent>, UpdateError> {
@@ -315,7 +315,7 @@ impl<I,S> Server<I,S> where I: SocketProvider<I,S> {
         //If we didn't have an existing client then handle a new client
         result.unwrap_or_else(|| self.internal.handle_new_client(addr, data, payload, &mut self.clients))
     }
-    
+
     fn find_client_by_id<'a>(clients: &'a mut ClientVec, id: ClientId) -> Option<&'a mut Connection> {
         clients.iter_mut().map(|c| c.as_mut()).find(|c| {
                 if let &Some(ref c) = c {
@@ -363,7 +363,7 @@ impl<I,S> ServerInternal<I,S> where I: SocketProvider<I,S> {
                 Some(self.send_client_challenge(client, private_data).map(|_| None))
             } else {
                 None
-            }; 
+            };
 
             existing_client_result.unwrap_or_else(|| {
                 //Find open index
@@ -372,7 +372,7 @@ impl<I,S> ServerInternal<I,S> where I: SocketProvider<I,S> {
                         let mut conn = Connection {
                             client_id: private_data.client_id,
                             state: ConnectionState::PendingResponse,
-                            channel: Channel::new(&private_data.server_to_client_key, &private_data.client_to_server_key, addr, self.protocol_id, idx, clients.len())
+                            channel: Channel::new(&private_data.server_to_client_key, &private_data.client_to_server_key, addr, self.protocol_id, idx, clients.len(), self.time)
                         };
 
                         self.send_client_challenge(&mut conn, private_data)?;
@@ -426,7 +426,7 @@ impl<I,S> ServerInternal<I,S> where I: SocketProvider<I,S> {
 
     fn validate_client_token(&mut self, req: &packet::ConnectionRequestPacket) -> Option<token::PrivateData> {
         if req.version != *NETCODE_VERSION_STRING {
-            trace!("Version mismatch expected {:?} but got {:?}", 
+            trace!("Version mismatch expected {:?} but got {:?}",
                 NETCODE_VERSION_STRING, req.version);
 
             return None;
@@ -686,7 +686,7 @@ mod test {
             let len = packet::encode(&mut data, PROTOCOL_ID, &packet, None, None).unwrap();
             self.socket.send_to(&data[..len], &self.server.get_local_addr().unwrap()).unwrap();
         }
-        
+
         fn validate_challenge(&mut self) {
             let mut data = [0; NETCODE_MAX_PAYLOAD_SIZE];
             self.server.update(0.0);
@@ -796,7 +796,7 @@ mod test {
                 Ok((_,p)) => assert!(false, "unexpected packet type {}", p.get_type_id()),
                 Err(o) => assert!(false, "unexpected {:?}", o)
             }
- 
+
         }
     }
 


### PR DESCRIPTION
Fixed a bug where new clients were only able to be accepted by the server within the first 5 seconds of the server starting.

After the server had been running for 5 seconds, any new connections were immediately timed out before the connection could be accepted.

I also exposed `token::DecodeError` so that failed attempts to decode the ConnectToken can be handled more gracefully by the calling code.