### PR TITLE
Fixes #46: Buffer.GetBytes could cause panics

### DIFF
--- a/go/netcode/buffer.go
+++ b/go/netcode/buffer.go
@@ -66,10 +66,15 @@ func (b *Buffer) GetByte() (byte, error) {
 // GetBytes returns a byte slice possibly smaller than length if bytes are not available from the
 // reader.
 func (b *Buffer) GetBytes(length int) ([]byte, error) {
-	if len(b.Buf) < length {
+	bufferLength := len(b.Buf)
+	bufferWindow := b.Pos + length
+	if bufferLength < length {
 		return nil, io.EOF
 	}
-	value := b.Buf[b.Pos : b.Pos+length]
+	if bufferWindow > bufferLength {
+		return nil, io.EOF
+	}
+	value := b.Buf[b.Pos:bufferWindow]
 	b.Pos += length
 	return value, nil
 }

--- a/go/netcode/buffer_test.go
+++ b/go/netcode/buffer_test.go
@@ -12,7 +12,6 @@ func TestBuffer(t *testing.T) {
 	if string(b.Buf) != "abcdefghij" {
 		t.Fatalf("error should have written 'abcdefghij' got '%s'\n", string(b.Buf))
 	}
-
 }
 
 func TestBuffer_Copy(t *testing.T) {
@@ -33,7 +32,6 @@ func TestBuffer_Copy(t *testing.T) {
 	if string(data) != "abcdefghij" {
 		t.Fatalf("error expeced: %s got %d\n", "abcdefghij", string(data))
 	}
-
 }
 
 func TestBuffer_GetByte(t *testing.T) {
@@ -73,7 +71,27 @@ func TestBuffer_GetBytes(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected EOF")
 	}
+}
 
+func TestBuffer_GetBytes_Issue46(t *testing.T) {
+	buf := []byte{
+		72, 101, 108, 108, 111, // Hello
+		71, 108, 101, 110, // Glen
+	}
+	b := NewBufferFromBytes(buf)
+
+	expected1 := "Hello"
+	bytes1, err := b.GetBytes(5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(bytes1) != expected1 {
+		t.Fatalf("expected %q got: %s\n", expected1, bytes1)
+	}
+
+	if _, err = b.GetBytes(5); err == nil {
+		t.Fatal(err)
+	}
 }
 
 func TestBuffer_GetInt8(t *testing.T) {
@@ -207,7 +225,6 @@ func TestBuffer_GetUint16(t *testing.T) {
 	if val != 0xffff {
 		t.Fatalf("expected 0xffff got: %x\n", val)
 	}
-
 }
 
 func TestBuffer_GetUint32(t *testing.T) {
@@ -263,5 +280,4 @@ func TestBuffer_WriteBytes(t *testing.T) {
 	if string(val) != "0123456789" {
 		t.Fatalf("expected 0123456789 got: %s %d\n", val, len(val))
 	}
-
 }


### PR DESCRIPTION
**Explanation:** `Buffer.GetBytes` only checks that the input size is less than the total buffer size so if we are near the end of the buffer and we ask for more bytes than there are left but still less than the total buffer size it'll panic.

**Example:** suppose we have a buffer `b` of size *4*. If we do two calls to `b.GetBytes(3)`, the second one will panic because we are asking for the last byte and two more.

I've also removed some unnecessary endlines in `buffer_test.go`

EDIT: Added a longer explanation here.