### PR TITLE
Update README.md with new rust fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ Other netcode.io repositories include:
 
 * [netcode.io C# implementation](https://github.com/KillaMaaki/Netcode.IO.NET)
 * [netcode.io Golang implementation](https://github.com/wirepair/netcode)
-* [netcode.io Rust implementation](https://github.com/vvanders/netcode.io)
+* [netcode.io Rust implementation](https://github.com/vvanders/netcode.io) (unmaintained)
+* [netcode.io Rust implementation](https://github.com/jaynus/netcode.io) (updated fork of [vvanders/netcode.io](https://github.com/vvanders/netcode.io))
 * [netcode.io for Unity](https://github.com/KillaMaaki/Unity-Netcode.IO)
 * [netcode.io for UE4](https://github.com/RedpointGames/netcode.io-UE4)
 * [netcode.io browser plugin](https://github.com/RedpointGames/netcode.io-browser)
@@ -44,9 +45,10 @@ Other netcode.io repositories include:
 These people are awesome:
 
 * [Val Vanders](https://github.com/vvanders) - Rust Implementation
+* [Walter Pearce](https://github.com/jaynus) - Rust Implementation
 * [Isaac Dawson](https://github.com/wirepair) - Golang Implementation
-* [June Rhodes](https://github.com/hach-que) - C# bindings, browser support, UE4 integration.
-* [Alan Stagner](https://github.com/KillaMaaki) - Unity integration, C# implementation.
+* [June Rhodes](https://github.com/hach-que) - C# bindings, browser support, UE4 integration
+* [Alan Stagner](https://github.com/KillaMaaki) - Unity integration, C# implementation
 
 Thanks for your contributions to netcode.io!
 


### PR DESCRIPTION
This PR includes a README.md update references a new fork of the previous rust implementation, which now works from the latest netcode.io master branch. Also updated language to leave original author cited, but mention current maintenance status of each fork. Closes #68