### PR TITLE
Reset loopback_client_num_packets_received before test.

### DIFF
--- a/netcode.c
+++ b/netcode.c
@@ -8558,7 +8558,7 @@ void test_loopback()
     // verify that we can exchange packets for both regular and loopback client post reconnect
 
     loopback_server_num_packets_received = 0;
-    loopback_server_num_packets_received = 0;
+    loopback_client_num_packets_received = 0;
     regular_server_num_packets_received = 0;
     regular_client_num_packets_received = 0;
     context.num_loopback_packets_sent_to_client = 0;


### PR DESCRIPTION
premake5 scan-build reported the following warning:

In file included from test.cpp:28:
./netcode.c:8560:5: warning: Value stored to 'loopback_server_num_packets_received' is never read
    loopback_server_num_packets_received = 0;

This looks like a copy/paste error that was added in 43e6c761 affecting the loopback test. While the test was passing, and still pass after this change, the test wasn't actually checking the receive count as intended (since it wasn't reset to 0 before the test).

After fix, scan-build shows:

scan-build: Removing directory '/tmp/scan-build-2018-11-14-161711-21680-1' because it contains no reports.
scan-build: No bugs found.