### PR TITLE
Add netcode_server_client_address function

### DIFF
--- a/netcode.c
+++ b/netcode.c
@@ -4780,10 +4780,10 @@ struct netcode_address_t * netcode_server_client_address( struct netcode_server_
     netcode_assert( server );
 
     if (!server->running)
-        return 0;
+        return NULL;
 
     if (client_index < 0 || client_index >= server->max_clients)
-        return 0;
+        return NULL;
 
     return &server->client_address[client_index];
 }

--- a/netcode.c
+++ b/netcode.c
@@ -4775,6 +4775,19 @@ uint64_t netcode_server_client_id( struct netcode_server_t * server, int client_
     return server->client_id[client_index];
 }
 
+struct netcode_address_t * netcode_server_client_address( struct netcode_server_t * server, int client_index )
+{
+    netcode_assert( server );
+
+    if (!server->running)
+        return 0;
+
+    if (client_index < 0 || client_index >= server->max_clients)
+        return 0;
+
+    return &server->client_address[client_index];
+}
+
 uint64_t netcode_server_next_packet_sequence( struct netcode_server_t * server, int client_index )
 {
     netcode_assert( client_index >= 0 );

--- a/netcode.h
+++ b/netcode.h
@@ -214,6 +214,8 @@ int netcode_server_client_connected( struct netcode_server_t * server, int clien
 
 uint64_t netcode_server_client_id( struct netcode_server_t * server, int client_index );
 
+struct netcode_address_t * netcode_server_client_address( struct netcode_server_t * server, int client_index );
+
 void netcode_server_disconnect_client( struct netcode_server_t * server, int client_index );
 
 void netcode_server_disconnect_all_clients( struct netcode_server_t * server );


### PR DESCRIPTION
This allows the server to check the IP address of a specified client index. It's added to the header file as I believe it's a useful part of the API exposed to users of this library. 