### PR TITLE
Fix netcode server to update address property when letting the system assign a port.

### DIFF
--- a/client_server.c
+++ b/client_server.c
@@ -28,6 +28,7 @@
 #include <assert.h>
 #include <signal.h>
 #include <inttypes.h>
+#include <stdlib.h>
 
 #define CONNECT_TOKEN_EXPIRY 30
 #define CONNECT_TOKEN_TIMEOUT 5
@@ -79,7 +80,7 @@ int main( int argc, char ** argv )
     server_config.protocol_id = PROTOCOL_ID;
     memcpy( &server_config.private_key, private_key, NETCODE_KEY_BYTES );
 
-    char * server_address = "[::1]:40000";
+    char * server_address = "[::1]:00000";
 
     struct netcode_server_t * server = netcode_server_create( server_address, &server_config, time );
 
@@ -91,6 +92,10 @@ int main( int argc, char ** argv )
 
     netcode_server_start( server, 1 );
 
+    // Create updated server address that includes system assigned port.
+    char *updated_server_address = calloc(256, 1);
+    snprintf(updated_server_address, 256, "[::1]:%i", netcode_server_get_port(server));
+
     uint8_t connect_token[NETCODE_CONNECT_TOKEN_BYTES];
 
     uint64_t client_id = 0;
@@ -100,7 +105,7 @@ int main( int argc, char ** argv )
     uint8_t user_data[NETCODE_USER_DATA_BYTES];
     netcode_random_bytes(user_data, NETCODE_USER_DATA_BYTES);
 
-    if ( netcode_generate_connect_token( 1, (NETCODE_CONST char**) &server_address, (NETCODE_CONST char**) &server_address, CONNECT_TOKEN_EXPIRY, CONNECT_TOKEN_TIMEOUT, client_id, PROTOCOL_ID, private_key, user_data, connect_token ) != NETCODE_OK )
+    if ( netcode_generate_connect_token( 1, (NETCODE_CONST char**) &updated_server_address, (NETCODE_CONST char**) &updated_server_address, CONNECT_TOKEN_EXPIRY, CONNECT_TOKEN_TIMEOUT, client_id, PROTOCOL_ID, private_key, user_data, connect_token ) != NETCODE_OK )
     {
         printf( "error: failed to generate connect token\n" );
         return 1;
@@ -190,6 +195,9 @@ int main( int argc, char ** argv )
     netcode_client_destroy( client );
 
     netcode_term();
+
+    free(updated_server_address);
+    updated_server_address = NULL;
     
     return 0;
 }

--- a/netcode.c
+++ b/netcode.c
@@ -503,6 +503,31 @@ char * netcode_address_to_string( struct netcode_address_t * address, char * buf
     }
 }
 
+int netcode_address_is_any_address(struct netcode_address_t *a) {
+    if (a->type == NETCODE_ADDRESS_IPV4) {
+        // 0.0.0.0
+        if (a->data.ipv4[0] == 0 &&
+            a->data.ipv4[1] == 0 &&
+            a->data.ipv4[2] == 0 &&
+            a->data.ipv4[3] == 0)
+            return 1;
+
+    } else if ( a->type == NETCODE_ADDRESS_IPV6 ) {
+        // [::] aka [0:0:0:0:0:0:0:0]
+        if (a->data.ipv6[0] == 0 &&
+            a->data.ipv6[1] == 0 &&
+            a->data.ipv6[2] == 0 &&
+            a->data.ipv6[3] == 0 &&
+            a->data.ipv6[4] == 0 &&
+            a->data.ipv6[5] == 0 &&
+            a->data.ipv6[6] == 0 &&
+            a->data.ipv6[7] == 0)
+            return 1;
+    }
+
+    return 0;
+}
+
 int netcode_address_equal( struct netcode_address_t * a, struct netcode_address_t * b )
 {
     netcode_assert( a );
@@ -542,31 +567,6 @@ int netcode_address_equal( struct netcode_address_t * a, struct netcode_address_
     }
 
     return 1;
-}
-
-int netcode_address_is_any_address(struct netcode_address_t *a) {
-    if (a->type == NETCODE_ADDRESS_IPV4) {
-        // 0.0.0.0
-        if (a->data.ipv4[0] == 0 &&
-            a->data.ipv4[1] == 0 &&
-            a->data.ipv4[2] == 0 &&
-            a->data.ipv4[3] == 0)
-            return 1;
-
-    } else if ( a->type == NETCODE_ADDRESS_IPV6 ) {
-        // [::] aka [0:0:0:0:0:0:0:0]
-        if (a->data.ipv6[0] == 0 &&
-            a->data.ipv6[1] == 0 &&
-            a->data.ipv6[2] == 0 &&
-            a->data.ipv6[3] == 0 &&
-            a->data.ipv6[4] == 0 &&
-            a->data.ipv6[5] == 0 &&
-            a->data.ipv6[6] == 0 &&
-            a->data.ipv6[7] == 0)
-            return 1;
-    }
-
-    return 0;
 }
 
 // ----------------------------------------------------------------

--- a/netcode.c
+++ b/netcode.c
@@ -514,6 +514,10 @@ int netcode_address_equal( struct netcode_address_t * a, struct netcode_address_
     if ( a->port != b->port )
         return 0;
 
+    // At this point, ports match. If either address is 0.0.0.0 or [::], then mark them as matching. These addresses are never routed, they're only used when listening.
+    if (netcode_address_is_any_address(a) || netcode_address_is_any_address(b))
+        return 1;
+
     if ( a->type == NETCODE_ADDRESS_IPV4 )
     {
         int i;
@@ -538,6 +542,31 @@ int netcode_address_equal( struct netcode_address_t * a, struct netcode_address_
     }
 
     return 1;
+}
+
+int netcode_address_is_any_address(struct netcode_address_t *a) {
+    if (a->type == NETCODE_ADDRESS_IPV4) {
+        // 0.0.0.0
+        if (a->data.ipv4[0] == 0 &&
+            a->data.ipv4[1] == 0 &&
+            a->data.ipv4[2] == 0 &&
+            a->data.ipv4[3] == 0)
+            return 1;
+
+    } else if ( a->type == NETCODE_ADDRESS_IPV6 ) {
+        // [::] aka [0:0:0:0:0:0:0:0]
+        if (a->data.ipv6[0] == 0 &&
+            a->data.ipv6[1] == 0 &&
+            a->data.ipv6[2] == 0 &&
+            a->data.ipv6[3] == 0 &&
+            a->data.ipv6[4] == 0 &&
+            a->data.ipv6[5] == 0 &&
+            a->data.ipv6[6] == 0 &&
+            a->data.ipv6[7] == 0)
+            return 1;
+    }
+
+    return 0;
 }
 
 // ----------------------------------------------------------------
@@ -3895,7 +3924,7 @@ struct netcode_server_t * netcode_server_create_overload( NETCODE_CONST char * s
     server->config = *config;
     server->socket_holder.ipv4 = socket_ipv4;
     server->socket_holder.ipv6 = socket_ipv6;
-    server->address = server_address1;
+    server->address = server_address1.type == NETCODE_ADDRESS_IPV4 ? server->socket_holder.ipv4.address : server->socket_holder.ipv6.address;
     server->flags = 0;
     server->time = time;
     server->running = 0;


### PR DESCRIPTION
At the moment, if you let the system assign a port (by passing port 0), the `server->address` property will have a port of 0 even after the system has assigned one. This means all incoming connection requests will be rejected because the port does not match.

This PR updates the `server->address` property to include the system assigned port once the socket is created. Fixes issue https://github.com/networkprotocol/netcode.io/issues/93.