### PR TITLE
Change implementation of netcode_sleep on linux and mac

### DIFF
--- a/netcode.c
+++ b/netcode.c
@@ -5179,7 +5179,10 @@ int netcode_generate_connect_token( int num_server_addresses,
 
 void netcode_sleep( double time )
 {
-    usleep( (int) ( time * 1000000 ) );
+    struct timespec ts;
+    ts.tv_sec = (time_t) time;
+    ts.tv_nsec = (long) ((time - (double) ( ts.tv_sec )) * 1000000000.0);
+    nanosleep( &ts, NULL );
 }
 
 static uint64_t start = 0;
@@ -5205,7 +5208,10 @@ double netcode_time()
 
 void netcode_sleep( double time )
 {
-    usleep( (int) ( time * 1000000 ) );
+    struct timespec ts;
+    ts.tv_sec = (time_t) time;
+    ts.tv_nsec = (long) ((time - (double) ( ts.tv_sec )) * 1000000000.0);
+    nanosleep( &ts, NULL );
 }
 
 double netcode_time()


### PR DESCRIPTION
`usleep` has been deprecated for a while now on POSIX systems. From the `usleep` [man page](https://www.man7.org/linux/man-pages/man3/usleep.3.html):

> 4.3BSD, POSIX.1-2001.  POSIX.1-2001 declares this function obsolete;
> use nanosleep(2) instead.  POSIX.1-2008 removes the specification of
> usleep().

This PR replaces it with `nanosleep`.