### PR TITLE
Fix clang warning about signed/unsigned comparison

### DIFF
--- a/netcode.c
+++ b/netcode.c
@@ -1671,7 +1671,7 @@ int netcode_replay_protection_already_received( struct netcode_replay_protection
     
     int index = (int) ( sequence % NETCODE_REPLAY_PROTECTION_BUFFER_SIZE );
 
-    if ( replay_protection->received_packet[index] == 0xFFFFFFFFFFFFFFFFLL )
+    if ( replay_protection->received_packet[index] == UINT64_MAX )
         return 0;
 
     if ( replay_protection->received_packet[index] >= sequence )


### PR DESCRIPTION
`netcode_replay_protection_t::received_packet[N]` is uint64_t, and it
was being compared to a signed literal (`0xFFFFFFFFFFFFFFFFLL`),
causing the following warning:

```
warning: comparison of integers of different signs: 'uint64_t' (aka 'unsigned long long') and 'long long' [-Wsign-compare]
    if ( replay_protection->received_packet[index] == 0xFFFFFFFFFFFFFFFFLL )
```

This switches the literal for UINT64_MAX, which is a constant for the
unsigned version of the same literal.